### PR TITLE
fix: fixed a mistake

### DIFF
--- a/apps/engine.c
+++ b/apps/engine.c
@@ -39,7 +39,7 @@ ibus_afrim_engine_class_init (IBusAfrimEngineClass *klass)
 static void
 ibus_afrim_engine_init (IBusAfrimEngine *afrim)
 {
-    afrim->engine_core = new_afrim_engine_core (afrim, parent_class);
+    afrim->engine_core = new_engine_core (afrim, parent_class);
     afrim->table = ibus_lookup_table_new (9, 0, TRUE, TRUE);
     g_object_ref_sink (afrim->table);
 }
@@ -55,7 +55,7 @@ ibus_afrim_engine_destroy (IBusAfrimEngine *afrim)
 
     if (afrim->engine_core)
         {
-            free_afrim_engine_core (afrim->engine_core);
+            free_engine_core (afrim->engine_core);
             afrim->engine_core = NULL;
         }
 

--- a/src/service/lib/src/lib.rs
+++ b/src/service/lib/src/lib.rs
@@ -22,7 +22,7 @@ pub struct EngineCore {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn new_afrim_engine_core(
+pub unsafe extern "C" fn new_engine_core(
     parent_engine: *mut IBusAfrimEngine,
     parent_engine_class: *mut IBusEngineClass,
 ) -> *mut EngineCore {
@@ -36,7 +36,7 @@ pub unsafe extern "C" fn new_afrim_engine_core(
 impl EngineCore {}
 
 #[no_mangle]
-pub unsafe extern "C" fn free_afrim_engine_core(engine_state: *mut EngineCore) {
+pub unsafe extern "C" fn free_engine_core(engine_state: *mut EngineCore) {
     std::mem::drop(Box::from_raw(engine_state));
 }
 


### PR DESCRIPTION
### Related to
- #1 

### Description
Use the term `afrim_engine_core` instead of `engine_core` can create confusions.

### Change
Revert the changes.