### PR TITLE
fix: implementation of `afrim-preprocessor`

### DIFF
--- a/apps/engine.c
+++ b/apps/engine.c
@@ -6,7 +6,6 @@
 static void ibus_afrim_engine_class_init (IBusAfrimEngineClass *klass);
 static void ibus_afrim_engine_init (IBusAfrimEngine *engine);
 static void ibus_afrim_engine_destroy (IBusAfrimEngine *engine);
-static void ibus_afrim_engine_enable (IBusEngine *engine);
 
 G_DEFINE_TYPE (IBusAfrimEngine, ibus_afrim_engine, IBUS_TYPE_ENGINE)
 
@@ -33,7 +32,10 @@ ibus_afrim_engine_class_init (IBusAfrimEngineClass *klass)
     engine_class->page_up = ibus_afrim_engine_page_up_button;
     engine_class->candidate_clicked = ibus_afrim_engine_candidate_clicked;
     engine_class->focus_out = ibus_afrim_engine_focus_out;
+    engine_class->focus_in = ibus_afrim_engine_focus_in;
     engine_class->enable = ibus_afrim_engine_enable;
+    engine_class->disable = ibus_afrim_engine_disable;
+    engine_class->reset = ibus_afrim_engine_reset;
 }
 
 static void
@@ -61,12 +63,4 @@ ibus_afrim_engine_destroy (IBusAfrimEngine *afrim)
 
     ((IBusObjectClass *)ibus_afrim_engine_parent_class)
         ->destroy ((IBusObject *)afrim);
-}
-
-static void
-ibus_afrim_engine_enable (IBusEngine *engine)
-{
-    // dummy call to tell the input context that the engine will utilize
-    // surrounding-text
-    ibus_engine_get_surrounding_text (engine, NULL, NULL, NULL);
 }

--- a/src/service/lib/src/lib.rs
+++ b/src/service/lib/src/lib.rs
@@ -116,6 +116,8 @@ pub unsafe extern "C" fn ibus_afrim_engine_process_key_event(
                 .as_mut()
                 .and_then(|afrim| afrim.preprocessor.pop_queue())
             {
+                // Some applications require this delay to work properly
+                std::thread::sleep(std::time::Duration::from_millis(10));
                 log::info!("executing command={:?}...", &command);
                 match command {
                     afrim_api::Command::CommitText(text) => {


### PR DESCRIPTION
### Related issues
- #2 

### Completion of
- #7 

### Description
This pr is there to complete the implementation of the `afrim-preprocessor`.

### Change
- [x] Fix problem on some text fields
- [x] Clear the text buffer when the user goes out of the text field