### PR TITLE
chore: reuse `corrosion-rs` cache source file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ include(GNUInstallDirs)
 set(LIBEXECDIR ${CMAKE_INSTALL_FULL_LIBEXECDIR})
 set(PKGDATADIR ${CMAKE_INSTALL_FULL_DATADIR})
 set(LOCALEDIR ${CMAKE_INSTALL_FULL_LOCALEDIR})
+set(CORROSION_SRC_DIR "${CMAKE_BINARY_DIR}/_deps/corrosion-src")
 
 add_definitions(
     -DPACKAGE_NAME="${PROJECT_NAME}"
@@ -31,8 +32,8 @@ pkg_check_modules(IBUS REQUIRED ibus-1.0)
 include(FetchContent)
 
 # Corrosion tools
-if(EXISTS "${CMAKE_BINARY_DIR}/_deps/corrosion-src")
-	add_subdirectory("${CMAKE_BINARY_DIR}/_deps/corrosion-src")
+if(EXISTS ${CORROSION_SRC_DIR})
+	add_subdirectory(${CORROSION_SRC_DIR})
 else()
 	FetchContent_Declare(
 	    Corrosion

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,12 +31,16 @@ pkg_check_modules(IBUS REQUIRED ibus-1.0)
 include(FetchContent)
 
 # Corrosion tools
-FetchContent_Declare(
-    Corrosion
-    GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-    GIT_TAG v0.5 # Optionally specify a commit hash, version tag or branch here
-)
-FetchContent_MakeAvailable(Corrosion)
+if(EXISTS "${CMAKE_BINARY_DIR}/_deps/corrosion-src")
+	add_subdirectory("${CMAKE_BINARY_DIR}/_deps/corrosion-src")
+else()
+	FetchContent_Declare(
+	    Corrosion
+	    GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
+	    GIT_TAG v0.5 # Optionally specify a commit hash, version tag or branch here
+	)
+	FetchContent_MakeAvailable(Corrosion)
+endif()
 # Adds Corrosion
 
 # The compiled library code is here


### PR DESCRIPTION
### Issue
- resolve #11

### Change
If `corrosion-rs` is present in the build folder, it will be reused. Otherwise, it will be fetched.